### PR TITLE
Bump golangci-lint to 1.27.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - checkout
       - run:
           name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
       - run:
           name: Check for Lint
           command: golangci-lint run

--- a/pkg/sif/lookup_test.go
+++ b/pkg/sif/lookup_test.go
@@ -19,7 +19,7 @@ func TestGetHeader(t *testing.T) {
 
 	header := fimg.GetHeader()
 	if header == nil {
-		t.Error("fimg.GetHeader(): returned nil")
+		t.Fatal("fimg.GetHeader(): returned nil")
 	}
 
 	if string(header.Magic[:9]) != "SIF_MAGIC" {


### PR DESCRIPTION
Bump `golangci-lint`, and address one piece of lint found by `staticcheck` linter:

```
pkg/sif/lookup_test.go:25:19: SA5011: possible nil pointer dereference (staticcheck)
        if string(header.Magic[:9]) != "SIF_MAGIC" {
```