### PR TITLE
Add GetReadSeeker

### DIFF
--- a/pkg/sif/load_test.go
+++ b/pkg/sif/load_test.go
@@ -107,6 +107,18 @@ func (m *mockSifReadWriter) Read(b []byte) (n int, err error) {
 	return n, err
 }
 
+func (m *mockSifReadWriter) ReadAt(b []byte, off int64) (n int, err error) {
+	if m.closed {
+		return 0, os.ErrInvalid
+	}
+
+	if off >= int64(len(m.buf)) {
+		return 0, io.EOF
+	}
+
+	return copy(b, m.buf[off:]), nil
+}
+
 func (m *mockSifReadWriter) Seek(offset int64, whence int) (ret int64, err error) {
 	if m.closed {
 		return 0, os.ErrInvalid

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -273,6 +273,15 @@ func (d *Descriptor) GetData(fimg *FileImage) []byte {
 	return fimg.Filedata[d.Fileoff : d.Fileoff+d.Filelen]
 }
 
+// GetReadSeeker returns a io.ReadSeeker that reads the data object associated with descriptor d
+// from image fimg.
+func (d *Descriptor) GetReadSeeker(fimg *FileImage) io.ReadSeeker {
+	if fimg.Amodebuf {
+		return io.NewSectionReader(fimg.Fp, d.Fileoff, d.Filelen)
+	}
+	return io.NewSectionReader(fimg.Reader, d.Fileoff, d.Filelen)
+}
+
 // GetName returns the name tag associated with the descriptor. Analogous to file name.
 func (d *Descriptor) GetName() string {
 	return strings.TrimRight(string(d.Name[:]), "\000")

--- a/pkg/sif/lookup.go
+++ b/pkg/sif/lookup.go
@@ -12,6 +12,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 )
 
@@ -254,11 +255,8 @@ func (fimg *FileImage) GetFromDescr(descr Descriptor) ([]*Descriptor, []int, err
 // GetData return a memory mapped byte slice mirroring the data object in a SIF file.
 func (d *Descriptor) GetData(fimg *FileImage) []byte {
 	if fimg.Amodebuf {
-		if _, err := fimg.Fp.Seek(d.Fileoff, 0); err != nil {
-			return nil
-		}
 		data := make([]byte, d.Filelen)
-		if n, _ := fimg.Fp.Read(data); int64(n) != d.Filelen {
+		if _, err := io.ReadFull(d.GetReadSeeker(fimg), data); err != nil {
 			return nil
 		}
 		return data

--- a/pkg/sif/sif.go
+++ b/pkg/sif/sif.go
@@ -290,6 +290,7 @@ type Header struct {
 // writing SIF files.
 type ReadWriter interface {
 	io.ReadWriteSeeker
+	io.ReaderAt
 	io.Closer
 	Name() string
 	Fd() uintptr


### PR DESCRIPTION
Currently, it is possible to obtain a byte slice of the data associated with an object descriptor using [GetData()](https://godoc.org/github.com/sylabs/sif/pkg/sif#Descriptor.GetData). When the [FileImage](https://godoc.org/github.com/sylabs/sif/pkg/sif#FileImage) is not `mmap`'d, calling `GetData()` to obtain a large data object consumes a significant amount of memory.

Callers may not require the entire data object in memory, and may only be interested in working with a portion of the object. To support this use case in an efficient way, I have added `GetReadSeeker()`, which returns a [`io.ReadSeeker`](https://golang.org/pkg/io/#ReadSeeker), which is a good match for this use case.

I have also fixed a subtle bug in `GetData()`. This function was reading via the [`io.Reader interface`](https://golang.org/pkg/io/#Reader), but not calling `Read` in a loop. `io.Reader`s are not required to return the number of requested bytes from the first call to `Read()`. To exercise the code path modified by this change, I have enhanced the unit test for `GetData()`.

As part of this work, I extended the `sif.ReadWriter interface` to include [`io.ReaderAt`](https://golang.org/pkg/io/#ReaderAt) in order to leverage [`*io.SectionReader`](https://golang.org/pkg/io/#SectionReader), which greatly simplifies implementation. Strictly speaking, semantic versioning may require a major version bump depending on how pedantic we would like to be. In practice, all uses of it I could find are passing a [`*os.File`](https://golang.org/pkg/os/#File), which satisfies `io.ReaderAt`.