### PR TITLE
Migrate to GitHub-native Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: go:modules
-    directory: /
-    update_schedule: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
Migrate Dependabot configuration to new location and format.