### PR TITLE
Update github.com/satori/go.uuid to address CVE-2021-3538

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sylabs/sif
 go 1.13
 
 require (
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76
 	github.com/spf13/cobra v1.0.0
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9
 )

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76 h1:ofyVTM1w4iyKwaQIlRR6Ip06mXXx5Cnz7a4mTGYq1hE=
+github.com/satori/go.uuid v1.2.1-0.20180404165556-75cca531ea76/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/internal/app/siftool/modif.go
+++ b/internal/app/siftool/modif.go
@@ -19,14 +19,19 @@ import (
 
 // New creates a new empty SIF file.
 func New(file string) error {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return fmt.Errorf("id generation failed: %v", err)
+	}
+
 	cinfo := sif.CreateInfo{
 		Pathname:   file,
 		Launchstr:  sif.HdrLaunch,
 		Sifversion: sif.HdrVersion,
-		ID:         uuid.NewV4(),
+		ID:         id,
 	}
 
-	_, err := sif.CreateContainer(cinfo)
+	_, err = sif.CreateContainer(cinfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/integrity/testdata/gen_sifs.go
+++ b/pkg/integrity/testdata/gen_sifs.go
@@ -13,15 +13,20 @@ import (
 )
 
 func createImage(path string, dis []sif.DescriptorInput) error {
+	id, err := uuid.NewV4()
+	if err != nil {
+		return fmt.Errorf("id generation failed: %v", err)
+	}
+
 	ci := sif.CreateInfo{
 		Pathname:   path,
 		Launchstr:  sif.HdrLaunch,
 		Sifversion: sif.HdrVersion,
-		ID:         uuid.NewV4(),
+		ID:         id,
 		InputDescr: dis,
 	}
 
-	_, err := sif.CreateContainer(ci)
+	_, err = sif.CreateContainer(ci)
 	return err
 }
 

--- a/pkg/sif/create_test.go
+++ b/pkg/sif/create_test.go
@@ -60,12 +60,17 @@ func TestDataStructs(t *testing.T) {
 }
 
 func TestCreateContainer(t *testing.T) {
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Fatalf("id generation failed: %v", err)
+	}
+
 	// general info for the new SIF file creation
 	cinfo := CreateInfo{
 		Pathname:   "testdata/testcontainer.sif",
 		Launchstr:  HdrLaunch,
 		Sifversion: HdrVersion,
-		ID:         uuid.NewV4(),
+		ID:         id,
 	}
 
 	// test container creation without any input descriptors


### PR DESCRIPTION
See https://github.com/hpcng/sif/security/advisories/GHSA-33m6-q9v5-62r7