### PR TITLE
chore: bump golangci-lint to v2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.4
+          version: v2.12
           skip-pkg-cache: true
           skip-build-cache: true
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,7 @@ linters:
     - gocritic
     - godot
     - godox
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - govet

--- a/pkg/integrity/sign_test.go
+++ b/pkg/integrity/sign_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -82,7 +82,7 @@ func TestOptSignGroupObjects(t *testing.T) {
 			}
 
 			if err == nil {
-				var got []uint32
+				got := make([]uint32, 0, len(gs.ods))
 				for _, od := range gs.ods {
 					got = append(got, od.ID())
 				}
@@ -562,7 +562,7 @@ func TestNewSigner(t *testing.T) {
 					if want, ok := tt.wantGroupObjects[groupID]; !ok {
 						t.Errorf("unexpected signer for group ID %v", groupID)
 					} else {
-						var got []uint32
+						got := make([]uint32, 0, len(signer.ods))
 						for _, od := range signer.ods {
 							got = append(got, od.ID())
 						}

--- a/pkg/integrity/verify_test.go
+++ b/pkg/integrity/verify_test.go
@@ -4,7 +4,7 @@
 //	For website terms of use, trademark policy, privacy policy and other
 //	project policies see https://lfprojects.org/policies
 //
-// Copyright (c) 2020-2024, Sylabs Inc. All rights reserved.
+// Copyright (c) 2020-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the LICENSE.md file
 // distributed with the sources of this project regarding your rights to use or distribute this
 // software.
@@ -734,7 +734,8 @@ func getSignedDummy(t *testing.T, fps ...[]byte) *sif.FileImage {
 		t.Fatal(err)
 	}
 
-	dis := []sif.DescriptorInput{di}
+	dis := make([]sif.DescriptorInput, 0, 1+len(fps))
+	dis = append(dis, di)
 
 	for _, fp := range fps {
 		di, err := sif.NewDescriptorInput(sif.DataSignature, strings.NewReader("sig"),

--- a/pkg/siftool/add_test.go
+++ b/pkg/siftool/add_test.go
@@ -2,7 +2,7 @@
 //   Apptainer a Series of LF Projects LLC.
 //   For website terms of use, trademark policy, privacy policy and other
 //   project policies see https://lfprojects.org/policies
-// Copyright (c) 2021-2023, Sylabs Inc. All rights reserved.
+// Copyright (c) 2021-2026, Sylabs Inc. All rights reserved.
 // This software is licensed under a 3-clause BSD license. Please consult the
 // LICENSE file distributed with the sources of this project regarding your
 // rights to use or distribute this software.
@@ -56,10 +56,11 @@ func Test_command_getAdd(t *testing.T) {
 
 			cmd := c.getAdd()
 
-			args := []string{
+			args := make([]string, 0, 2+len(tt.flags))
+			args = append(args,
 				makeTestSIF(t, false),
 				filepath.Join("testdata", "input", "input.bin"),
-			}
+			)
 			args = append(args, tt.flags...)
 
 			runCommand(t, cmd, args, nil)


### PR DESCRIPTION
- Import sylabs/sif#440 
- Import sylabs/sif#458

which had original descriptions of

> Bump `golangci-lint` to v2.8. Address lint found by updated linters.

> Replace deprecated `gomodguard` linter.